### PR TITLE
suggestion: 'brightness here'

### DIFF
--- a/23/mornings/exception.md
+++ b/23/mornings/exception.md
@@ -7,5 +7,5 @@ no one's heard of it. They don't care.
 Most of this universe knows no morning!  
 Empty stretching black, distant stars unblinking.  
 
-It's only here, this fragile in-between:  
+The brightness right here,  
 our surface-dweller secret.  


### PR DESCRIPTION
Before I reworked this poem to make the first line into the title and break up the last line, [@hezzerdavis](https://twitter.com/hezzerdavis) suggested the following modification to the last line:

> The brightness up here: our surface-dweller secret.

I removed the "up", since we're contrasting the surface not just with the ocean depths, but also with the empty stretches of space.

Not sure which version I like more; creating this to look at them side-by-side and sit on it a bit.